### PR TITLE
Refactor/#86 mainproduct show case

### DIFF
--- a/src/components/common/Skeleton/MainProductShowcaseSkeleton.tsx
+++ b/src/components/common/Skeleton/MainProductShowcaseSkeleton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+function MainProductShowcaseSkeleton() {
+  return (
+    <section className="mt-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-10 items-start">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col items-center custom930:flex-row gap-6 w-full animate-pulse"
+          >
+            <div className="w-full sm:w-[250px] max-w-[250px] min-h-[250px] max-h-[250px] bg-gray-200 rounded-xl" />
+            <div className="text-center max-w-[400px] w-full sm:text-left space-y-3">
+              <div className="h-6 bg-gray-200 rounded w-3/4 mx-auto sm:mx-0" />
+              <div className="h-4 bg-gray-200 rounded w-full mx-auto sm:mx-0" />
+              <div className="h-4 bg-gray-200 rounded w-5/6 mx-auto sm:mx-0" />
+              <div className="h-10 bg-gray-300 rounded-lg w-1/2 mx-auto sm:mx-0 mt-2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default React.memo(MainProductShowcaseSkeleton);

--- a/src/pages/home/MainProductShowcase.tsx
+++ b/src/pages/home/MainProductShowcase.tsx
@@ -1,119 +1,113 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Ps5Png from '../../assets/PlayStation.png';
 import MacBookPng from '../../assets/MacBookPro.png';
-import AirPodMaxPng from '../../assets/AirPodsMax.png';
 import VisionProPng from '../../assets/VIsionPro.png';
 import Ps5Webp from '../../assets/PlayStation.webp';
 import MacBookWebp from '../../assets/MacBookPro.webp';
 import AirPodMaxWebp from '../../assets/AirPodsMax.webp';
 import VisionProWebp from '../../assets/VIsionPro.webp';
-import Button from '../../components/common/Button/Button';
 import imageFallbackHandler from '../../util/imageErrorHandler';
+import Button from '../../components/common/Button/Button';
+import MainProductShowcaseSkeleton from '../../components/common/Skeleton/MainProductShowcaseSkeleton';
+
+type ShowType = {
+  id: number;
+  alt: string;
+  title: string;
+  description: string;
+  webp: string;
+  png: string;
+  button?: boolean;
+}[];
+
+const showcaseData: ShowType = [
+  {
+    id: 1,
+    alt: 'Playstation5',
+    title: 'Playstation 5',
+    description:
+      'Incredibly powerful CPUs, GPUs, and an SSD with <br />\n' +
+      '              integrated I/O will redefine your PlayStation <br />\n' +
+      '              experience',
+    webp: Ps5Webp,
+    png: Ps5Png,
+  },
+  {
+    id: 2,
+    alt: 'Macbook Air',
+    title: 'MacBook Air',
+    description:
+      '  The new 15-inch MacBook Air makes room for more of what you love with a spacious\n' +
+      '              Liquid Retina display.',
+    webp: MacBookWebp,
+    png: MacBookPng,
+    button: true,
+  },
+  {
+    id: 3,
+    alt: 'Apple AirPods Max',
+    title: 'Apple AirPods Max',
+    description: 'Computational audio. Listen, powerful.',
+    webp: AirPodMaxWebp,
+    png: AirPodMaxWebp,
+  },
+  {
+    id: 4,
+    alt: 'Apple Vision Pro',
+    title: 'Apple Vision Pro',
+    description: ' An immersive way to experience entertainment.',
+    webp: VisionProWebp,
+    png: VisionProPng,
+  },
+];
 
 function MainProductShowcase() {
-  return (
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setIsLoading(true), 500);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return isLoading ? (
     <section className="mt-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-10  items-start">
-        <div className="flex flex-col items-center custom930:flex-row gap-6">
-          <div className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] min-h-[250px]">
-            <picture>
-              <source type="image/webp" srcSet={Ps5Webp} />
-              <img
-                src={Ps5Png}
-                alt="Playstation5"
-                onError={imageFallbackHandler}
-                width={400}
-                height={400}
-                className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] object-contain"
-              />
-            </picture>
+        {showcaseData.map((item) => (
+          <div key={item.id} className="flex flex-col items-center custom930:flex-row gap-6 w-full">
+            {isLoading ? (
+              <div className="w-full sm:w-[250px] max-w-[250px] aspect-[1/1]">
+                <picture>
+                  <source type="image/webp" srcSet={item.webp} />
+                  <img
+                    src={item.png}
+                    alt={item.alt}
+                    width={250}
+                    height={250}
+                    onError={imageFallbackHandler}
+                    className="w-full h-full object-contain"
+                  />
+                </picture>
+              </div>
+            ) : (
+              <div className="w-full sm:w-[250px] aspect-[1/1] bg-gray-100 animate-pulse rounded-lg" />
+            )}
+            <div className="text-center max-w-[400px] w-full sm:text-left">
+              <h2 className="text-2xl sm:text-4xl leading-tight font-semibold mb-2">
+                {item.title}
+              </h2>
+              <p className="text-sm sm:text-base text-gray-500 leading-6">{item.description}</p>
+              {item.button && isLoading && (
+                <Button size="medium" color="mediumBlack">
+                  Shop Now
+                </Button>
+              )}
+            </div>
           </div>
-          <div className="text-center max-w-[400px] w-full sm:text-left ">
-            <h2 className="text-3xl sm:text-5xl font-medium leading-tight mb-2">Playstation 5</h2>
-            <p className="text-sm sm:text-base text-gray-500 leading-6">
-              Incredibly powerful CPUs, GPUs, and an SSD with <br />
-              integrated I/O will redefine your PlayStation <br />
-              experience
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-col items-center custom930:flex-row gap-6">
-          <div className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] min-h-[250px]">
-            <picture>
-              <source type="image/webp" srcSet={MacBookWebp} />
-              <img
-                src={MacBookPng}
-                alt="Macbook Air"
-                width={400}
-                height={400}
-                className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] object-contain"
-                onError={imageFallbackHandler}
-              />
-            </picture>
-          </div>
-
-          <div className="text-center max-w-[400px] w-full h-full sm:text-left">
-            <h2 className="text-4xl sm:text-6xl font-thin leading-tight">
-              Macbook <span className="font-thin">Air</span>
-            </h2>
-            <p className="text-sm text-gray-500 my-2">
-              The new 15-inch MacBook Air makes room for more of what you love with a spacious
-              Liquid Retina display.
-            </p>
-            <Button size="medium" color="mediumBlack">
-              Shop Now
-            </Button>
-          </div>
-        </div>
-
-        <div className="flex flex-col items-center custom930:flex-row gap-6">
-          <div className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] min-h-[250px]">
-            <picture>
-              <source type="image/webp" srcSet={AirPodMaxWebp} />
-
-              <img
-                src={AirPodMaxPng}
-                alt="Apple AirPods Max"
-                width={400}
-                height={400}
-                onError={imageFallbackHandler}
-                className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] object-contain"
-              />
-            </picture>
-          </div>
-
-          <div className="text-center max-w-[400px] w-full sm:text-left">
-            <h2 className="text-2xl sm:text-3xl leading-tight">Apple AirPods Max</h2>
-            <p className="text-sm text-gray-500 leading-6">
-              Computational audio. Listen, powerful.
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-col items-center custom930:flex-row gap-6">
-          <div className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] min-h-[250px]">
-            <picture>
-              <source type="image/webp" srcSet={VisionProWebp} />
-              <img
-                src={VisionProPng}
-                alt="Apple Vision Pro"
-                width={400}
-                height={400}
-                onError={imageFallbackHandler}
-                className="w-full sm:w-[250px] max-w-[250px] max-h-[250px] object-contain"
-              />
-            </picture>
-          </div>
-          <div className="text-center max-w-[400px] w-full sm:text-left">
-            <h2 className="text-2xl sm:text-3xl leading-tight">Apple Vision Pro</h2>
-            <p className="text-sm text-gray-400 leading-6">
-              An immersive way to experience entertainment.
-            </p>
-          </div>
-        </div>
+        ))}
       </div>
     </section>
+  ) : (
+    <MainProductShowcaseSkeleton />
   );
 }
 


### PR DESCRIPTION
- 이미지가 렌더링되기 전 layout shift(CLS) 문제가 발생해 사용자 경험이 저하됨
- 제품 소개 섹션에 skeleton 컴포넌트를 도입하여 초기 렌더링 안정성 확보
- 조건부 렌더링으로 로딩 상태에 따른 UI 분리

# cls 개선 전
![스크린샷 2025-04-10 183327](https://github.com/user-attachments/assets/ca7af6bb-8d0b-4343-8e2b-fecd1004d774)


# cls 개선 후
![스크린샷 2025-04-10 181807](https://github.com/user-attachments/assets/486842ec-e64c-419b-ae59-92c11494b729)

close #86 